### PR TITLE
Remove probes on all deployment containers

### DIFF
--- a/tests/local/test_unit.py
+++ b/tests/local/test_unit.py
@@ -150,18 +150,6 @@ spec:
         ports:
         - containerPort: 443
         - containerPort: 80
-        livenessProbe:
-          httpGet:
-            path: /index.html
-            port: 80
-          initialDelaySeconds: 30
-          timeoutSeconds: 1
-        readinessProbe:
-          httpGet:
-            path: /index.html
-            port: 80
-          initialDelaySeconds: 30
-          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /etc/nginx/ssl
           name: secret-volume


### PR DESCRIPTION
The various probes reduce the development cycle as we need to wait for
it to succeed before the application is ready. In cases where you have
multiple containers (like PHP with 2 containers nginx and php-fpm),
removing the probes on only one container is not enough.